### PR TITLE
docs(api): add Swagger/OpenAPI annotations for server handlers

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -27,6 +27,10 @@ import (
 // @description     API для управления задачами парсинга
 // @host            localhost:8080
 // @BasePath        /api
+// @securityDefinitions.apikey BearerAuth
+// @in header
+// @name Authorization
+// @description JWT токен в формате: Bearer <token>
 func main() {
 	cfg := config.Load()
 

--- a/internal/server/archive.go
+++ b/internal/server/archive.go
@@ -2,6 +2,24 @@ package server
 
 import "github.com/gin-gonic/gin"
 
+// GetArchiveGames godoc
+// @Summary      Получить архивные матчи
+// @Description  Возвращает архивные матчи (эндпоинт в разработке)
+// @Tags         archive
+// @Produce      json
+// @Success      501  {object}  errorResponse
+// @Security     BearerAuth
+// @Router       /archive/ [get]
 func (h *Handler) GetArchiveGames(c *gin.Context) {}
 
+// UploadArchiveGames godoc
+// @Summary      Загрузить архивные матчи
+// @Description  Загружает архивные матчи из файла (эндпоинт в разработке)
+// @Tags         archive
+// @Accept       multipart/form-data
+// @Produce      json
+// @Param        file  formData  file  true  "Файл архива"
+// @Success      501   {object}  errorResponse
+// @Security     BearerAuth
+// @Router       /archive/upload [post]
 func (h *Handler) UploadArchiveGames(c *gin.Context) {}

--- a/internal/server/export.go
+++ b/internal/server/export.go
@@ -10,6 +10,19 @@ import (
 	"github.com/zollidan/esmeralda/internal/stats"
 )
 
+// ExportGames godoc
+// @Summary      Экспортировать матчи в Excel
+// @Description  Формирует XLSX файл по матчам за период date_start - date_end
+// @Tags         export
+// @Produce      application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+// @Param        date_start  query     string  true  "Дата начала периода (YYYY-MM-DD)"
+// @Param        date_end    query     string  true  "Дата конца периода (YYYY-MM-DD)"
+// @Success      200         {file}    file
+// @Failure      400         {object}  errorResponse
+// @Failure      404         {object}  errorResponse
+// @Failure      500         {object}  errorResponse
+// @Security     BearerAuth
+// @Router       /export/ [get]
 func (h *Handler) ExportGames(c *gin.Context) {
 	dateStartStr := c.Query("date_start")
 	dateEndStr := c.Query("date_end")

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -39,6 +39,13 @@ func NewHandler(producer *queue.Producer, cfg *config.Config, rdb *redis.Client,
 	}
 }
 
+// Health godoc
+// @Summary      Проверка доступности сервиса
+// @Description  Возвращает статус API
+// @Tags         health
+// @Produce      json
+// @Success      200  {object}  map[string]string
+// @Router       /health [get]
 func (h *Handler) Health(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "ok"})
 }

--- a/internal/server/tasks.go
+++ b/internal/server/tasks.go
@@ -18,6 +18,26 @@ type createTaskRequest struct {
 	Date string `json:"date" binding:"required"`
 }
 
+type messageResponse struct {
+	Message string `json:"message"`
+}
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+// CreateTask godoc
+// @Summary      Создать задачу парсинга
+// @Description  Создает новую задачу на парсинг матчей за указанную дату
+// @Tags         tasks
+// @Accept       json
+// @Produce      json
+// @Param        request body      createTaskRequest true "Дата задачи"
+// @Success      201     {object}  models.Task
+// @Failure      400     {object}  errorResponse
+// @Failure      500     {object}  errorResponse
+// @Security     BearerAuth
+// @Router       /tasks/ [post]
 func (h *Handler) CreateTask(c *gin.Context) {
 	var req createTaskRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -59,6 +79,15 @@ func (h *Handler) CreateTask(c *gin.Context) {
 	c.JSON(http.StatusCreated, record)
 }
 
+// GetTasks godoc
+// @Summary      Получить список задач
+// @Description  Возвращает все задачи, отсортированные по времени создания
+// @Tags         tasks
+// @Produce      json
+// @Success      200  {array}   models.Task
+// @Failure      500  {object}  errorResponse
+// @Security     BearerAuth
+// @Router       /tasks/ [get]
 func (h *Handler) GetTasks(c *gin.Context) {
 	tasks, err := h.tasks.GetAllOrdered(c.Request.Context())
 	if err != nil {
@@ -68,6 +97,18 @@ func (h *Handler) GetTasks(c *gin.Context) {
 	c.JSON(http.StatusOK, tasks)
 }
 
+// GetTask godoc
+// @Summary      Получить задачу по ID
+// @Description  Возвращает одну задачу по идентификатору
+// @Tags         tasks
+// @Produce      json
+// @Param        id   path      string  true  "ID задачи"
+// @Success      200  {object}  models.Task
+// @Failure      400  {object}  errorResponse
+// @Failure      404  {object}  errorResponse
+// @Failure      500  {object}  errorResponse
+// @Security     BearerAuth
+// @Router       /tasks/{id} [get]
 func (h *Handler) GetTask(c *gin.Context) {
 	taskID := c.Param("id")
 	if taskID == "" {
@@ -88,6 +129,18 @@ func (h *Handler) GetTask(c *gin.Context) {
 	c.JSON(http.StatusOK, task)
 }
 
+// DeleteTask godoc
+// @Summary      Удалить задачу
+// @Description  Удаляет задачу по ID
+// @Tags         tasks
+// @Produce      json
+// @Param        id   path      string  true  "ID задачи"
+// @Success      200  {object}  messageResponse
+// @Failure      400  {object}  errorResponse
+// @Failure      404  {object}  errorResponse
+// @Failure      500  {object}  errorResponse
+// @Security     BearerAuth
+// @Router       /tasks/{id} [delete]
 func (h *Handler) DeleteTask(c *gin.Context) {
 	taskID := c.Param("id")
 	if taskID == "" {
@@ -113,6 +166,14 @@ func (h *Handler) DeleteTask(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "задача успешно удалена"})
 }
 
+// StreamTasks godoc
+// @Summary      Поток обновлений задач (SSE)
+// @Description  Открывает Server-Sent Events поток с актуальным списком и изменениями задач
+// @Tags         tasks
+// @Produce      text/event-stream
+// @Success      200  {string}  string  "SSE stream"
+// @Security     BearerAuth
+// @Router       /tasks/stream [get]
 func (h *Handler) StreamTasks(c *gin.Context) {
 	c.Header("Content-Type", "text/event-stream")
 	c.Header("Cache-Control", "no-cache")

--- a/internal/server/users.go
+++ b/internal/server/users.go
@@ -17,6 +17,18 @@ type LoginUserResponse struct {
 	Token string `json:"token"`
 }
 
+// PostLoginUser godoc
+// @Summary      Авторизация пользователя
+// @Description  Проверяет учетные данные и возвращает JWT токен
+// @Tags         auth
+// @Accept       json
+// @Produce      json
+// @Param        request  body      LoginUserRequest   true  "Логин и пароль"
+// @Success      200      {object}  LoginUserResponse
+// @Failure      400      {object}  errorResponse
+// @Failure      401      {object}  errorResponse
+// @Failure      500      {object}  errorResponse
+// @Router       /auth/login [post]
 func (h *Handler) PostLoginUser(c *gin.Context) {
 	var req LoginUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {


### PR DESCRIPTION
### Motivation
- Add in-code Swagger/OpenAPI annotations so `swag` can generate API documentation for HTTP handlers.  
- Ensure secured endpoints are described with JWT `BearerAuth` so the docs include the `Authorization` header scheme.

### Description
- Added Swagger comments for the health endpoint in `internal/server/handlers.go` and defined `BearerAuth` in `cmd/api/main.go`.  
- Documented auth login (`/api/auth/login`) with request/response models in `internal/server/users.go`.  
- Annotated all task endpoints (create, list, get by id, delete, SSE stream) and introduced `errorResponse` and `messageResponse` response schemas in `internal/server/tasks.go`.  
- Added OpenAPI annotations for the export endpoint and query parameters in `internal/server/export.go` and added annotations for archive endpoints (stubs) in `internal/server/archive.go` to expose them in docs.

### Testing
- Ran unit tests with `go test ./internal/server -run TestNewHandler -count=1`, which passed.  
- Attempted to generate docs with `make swagger`, which failed because the `swag` binary is not installed in the environment.  
- Attempted `go run github.com/swaggo/swag/cmd/swag@latest init -g cmd/api/main.go --output docs`, which failed due to restricted access to `proxy.golang.org` in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca8b091f8c832d9c333f80f2815c7e)